### PR TITLE
Add support to Laravel 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,18 +16,19 @@
         }
     ],
     "require": {
-        "php": ">=7.1.3",
-        "illuminate/support": "^5.6",
-        "laravelcollective/html": "^5.6",
-        "illuminate/translation": "^5.6",
-        "doctrine/dbal": "~2.6",
-        "symfony/finder": "~4.0"
+        "php": ">=7.2",
+        "illuminate/support": "^6.0",
+        "laravelcollective/html": "^6.0",
+        "illuminate/translation": "^6.0",
+        "doctrine/dbal": "~2.9",
+        "symfony/finder": "~4.3",
+        "laravel/helpers": "^1.1"
     },
     "require-dev": {
-        "phpspec/phpspec": "~3.0",
+        "phpspec/phpspec": "~5.1",
         "fzaninotto/faker": "~1.4",
         "mockery/mockery": "0.9.*",
-        "phpunit/phpunit": "~7.0"
+        "phpunit/phpunit": "~8.0"
     },
     "autoload": {
         "classmap": [


### PR DESCRIPTION
Change dependencies to add support for Laravel 6.
Added laravel/helpers once it is now a package and it is being used.